### PR TITLE
💄 [#60]; ui: 메인 페이지 로고 위치 통일

### DIFF
--- a/tutti/app/home/page.tsx
+++ b/tutti/app/home/page.tsx
@@ -110,7 +110,7 @@ const HomePageContent = () => {
         />
 
         <div className="flex h-dvh max-h-dvh min-h-0 grow flex-col overflow-hidden">
-          <div className="flex min-h-17 shrink-0 items-center px-4">
+          <div className="flex min-h-17 shrink-0 items-center px-3 md:px-5">
             <LogoLink />
           </div>
           <main className="relative flex min-h-0 grow flex-col overflow-y-auto bg-[#05070a]">


### PR DESCRIPTION
## Summary
- 메인 페이지(home) 로고 영역 padding을 다른 페이지(player/before-create/library)와 동일하게 \`px-3 md:px-5\`로 통일

## Test plan
- [x] /home 페이지에서 Tutti 로고 위치 확인
- [x] 다른 페이지(/player, /library)와 로고 좌측 위치 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)